### PR TITLE
가독성 실습을 위한 테스트 케이스 개선

### DIFF
--- a/src/test/kotlin/camp/nextstep/edu/immutable/step3/ReadabilityTest1.kt
+++ b/src/test/kotlin/camp/nextstep/edu/immutable/step3/ReadabilityTest1.kt
@@ -5,7 +5,11 @@ import org.junit.jupiter.api.Test
 
 /** inline 상태로 사용 */
 private class EmployeeManager1 {
-    private val employees: List<Employee> = emptyList()
+    private val employees: List<Employee> = listOf(
+        Employee("김태현"),
+        Employee("김수현"),
+        Employee("박재성"),
+    )
 
     val kimEmployees: List<Employee> = employees
         .filter { TODO("구현해보세요 :)") }
@@ -22,6 +26,6 @@ class ReadabilityTest1 {
         val actual = employeeManager.kimEmployees
 
         // then
-        assertThat(actual).allMatch { it.name.startsWith("김") }
+        assertThat(actual).containsExactly(Employee("김태현"), Employee("김수현"))
     }
 }

--- a/src/test/kotlin/camp/nextstep/edu/immutable/step3/ReadabilityTest2.kt
+++ b/src/test/kotlin/camp/nextstep/edu/immutable/step3/ReadabilityTest2.kt
@@ -5,7 +5,11 @@ import org.junit.jupiter.api.Test
 
 /** 확장함수로 분리 */
 private class EmployeeManager2 {
-    private val employees: List<Employee> = emptyList()
+    private val employees: List<Employee> = listOf(
+        Employee("김태현"),
+        Employee("김수현"),
+        Employee("박재성"),
+    )
     val kimEmployees: List<Employee> = employees.filterKim()
 
     private fun List<Employee>.filterKim(): List<Employee> {
@@ -24,6 +28,6 @@ class ReadabilityTest2 {
         val actual = employeeManager.kimEmployees
 
         // then
-        assertThat(actual).allMatch { it.name.startsWith("김") }
+        assertThat(actual).containsExactly(Employee("김태현"), Employee("김수현"))
     }
 }

--- a/src/test/kotlin/camp/nextstep/edu/immutable/step3/ReadabilityTest3.kt
+++ b/src/test/kotlin/camp/nextstep/edu/immutable/step3/ReadabilityTest3.kt
@@ -9,15 +9,17 @@ private data class Employees(private val values: List<Employee>) {
     }
 
     fun toList(): List<Employee> = values.toList()
-
-    companion object {
-        val EMPTY = Employees(emptyList())
-    }
 }
 
 /** 클래스로 분리 */
 private class EmployeeManager3 {
-    private val employees: Employees = Employees.EMPTY
+    private val employees: Employees = Employees(
+        listOf(
+            Employee("김태현"),
+            Employee("김수현"),
+            Employee("박재성"),
+        )
+    )
     val kimEmployees: Employees = employees.filterKim()
 }
 
@@ -32,6 +34,6 @@ class ReadabilityTest3 {
         val actual = employeeManager.kimEmployees.toList()
 
         // then
-        assertThat(actual).allMatch { it.name.startsWith("김") }
+        assertThat(actual).containsExactly(Employee("김태현"), Employee("김수현"))
     }
 }


### PR DESCRIPTION
가독성 관련 테스트 케이스의 assert문들이 모두 List를 순회하는 형태의 assert문이라 테스트를 수행하면 ReadabilityTest1이 성공하고 있습니다.
실패하는 테스트 케이스로 변경하기 위해 가독성 관련 실습들에 모두 fake Employee 데이터를 넣어놓고 함수를 구현해야만 성공하도록 변경했습니다.
